### PR TITLE
Kt/m invoice info

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -4,5 +4,6 @@ class InvoicesController < ApplicationController
 
     @merchant = Merchant.find(params[:merchant_id])
     @invoice = Invoice.find(params[:id])
+    
   end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,4 +1,5 @@
 class InvoiceItem < ApplicationRecord
+  enum status: { packaged: 0, pending: 1, shipped: 2 }
   belongs_to :invoice 
   belongs_to :item 
 end

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -5,6 +5,20 @@
 <p><strong>Customer Name: </strong> <%= @invoice.customer.first_name%> <%= @invoice.customer.last_name %></p>
 <p><strong>Invoice Status: </strong><%= @invoice.status %></p>
 <p><strong>Created at: </strong><%= @invoice.created_at.strftime('%A, %B %d, %Y')%> </p>
+<br>
+<br>
+
+<p><h4>Invoice Items Ordered: </h4></p>
+<% @invoice.items.each do |item| %>
+  <p><strong>Name: </strong><%= item.name %></p>
+  <% item.invoice_items.each do |invoice_item| %>
+  <p><strong>Unit Price: </strong><%= invoice_item.unit_price %></p>
+  <p><strong>Quantity: </strong><%= invoice_item.quantity %></p>
+  <p><strong>Status: </strong><%= invoice_item.status %></p>
+  <% end %>
+<% end %>
+
+
 
 
 

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -18,15 +18,17 @@ RSpec.describe "Merchant Invoice Show" do
     @invoice3 = Invoice.create!(status: 1, customer_id: @customer3.id, created_at: "2022-11-01 11:00:00 UTC")
     
     InvoiceItem.create!(quantity: 1, unit_price: 5000, status: "Pending", item_id: @item1.id, invoice_id: @invoice1.id)
+    InvoiceItem.create!(quantity: 1, unit_price: 5000, status: "Pending", item_id: @item2.id, invoice_id: @invoice1.id)
+    InvoiceItem.create!(quantity: 1, unit_price: 5000, status: "Pending", item_id: @item1.id, invoice_id: @invoice1.id)
 
   end
 
-  describe 'US-15: Merchant Item Show Page'do 
+  describe 'US-15: Merchant Invoice Show Page'do 
     describe 'As a merchant, when I visit my invoice show page, I see info related to that invoice' do 
       it 'I see info of (invoice id, invoice status, invoice created_at date in format (Monday, July 18, 2019), & customer first and last name' do 
 
         visit merchant_invoice_path(@merchant1, @invoice1)
-        save_and_open_page
+       
         expect(page).to have_content(@invoice1.id)
         expect(page).to have_content(@invoice1.status)
         expect(page).to have_content(@invoice1.created_at.strftime('%A, %B %d, %Y'))
@@ -35,6 +37,28 @@ RSpec.describe "Merchant Invoice Show" do
         expect(page).to_not have_content(@invoice2.customer.first_name)
         expect(page).to_not have_content(@invoice2.customer.last_name)
         
+      end
+    end
+  end
+
+  describe 'US-16: Invoice Item Information ' do 
+    describe 'As a merchant, when I visit my merchant invoice show page, I see all of my items on the invoice including:' do 
+      it 'Displays item name, the quantity of the item ordered, price the item sold for, invoice item status, and i do not see any info related to items for other merchants' do 
+       
+        visit merchant_invoice_path(@merchant1, @invoice1)
+
+        expect(page).to have_content(@item1.name)
+        expect(page).to have_content(@item2.name)
+        expect(page).to have_content(@item2.unit_price)
+        expect(page).to have_content(@item1.unit_price)
+        expect(page).to have_content(@item1.quantity)
+        expect(page).to have_content(@item2.quantity)
+        expect(page).to have_content(@item1.status)
+        expect(page).to have_content(@item2.status)
+        expect(page).to_not have_content(@item3.name)
+        expect(page).to_not have_content(@item3.unit_price)
+        expect(page).to_not have_content(@item3.quantity)
+
       end
     end
   end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe "Merchant Invoice Show" do
     @invoice2 = Invoice.create!(status: 1, customer_id: @customer1.id, created_at: "2022-11-01 11:00:00 UTC")
     @invoice3 = Invoice.create!(status: 1, customer_id: @customer3.id, created_at: "2022-11-01 11:00:00 UTC")
     
-    InvoiceItem.create!(quantity: 1, unit_price: 5000, status: "Pending", item_id: @item1.id, invoice_id: @invoice1.id)
-    InvoiceItem.create!(quantity: 1, unit_price: 5000, status: "Pending", item_id: @item2.id, invoice_id: @invoice1.id)
-    InvoiceItem.create!(quantity: 1, unit_price: 5000, status: "Pending", item_id: @item1.id, invoice_id: @invoice1.id)
+    @invoice_item1 = InvoiceItem.create!(quantity: 1, unit_price: 5000, status: 0, item_id: @item1.id, invoice_id: @invoice1.id)
+    @invoice_item2 =InvoiceItem.create!(quantity: 2, unit_price: 5000, status: 1, item_id: @item2.id, invoice_id: @invoice1.id)
+    @invoice_item3 = InvoiceItem.create!(quantity: 1, unit_price: 5000, status: 2, item_id: @item3.id, invoice_id: @invoice2.id)
 
   end
 
@@ -28,7 +28,7 @@ RSpec.describe "Merchant Invoice Show" do
       it 'I see info of (invoice id, invoice status, invoice created_at date in format (Monday, July 18, 2019), & customer first and last name' do 
 
         visit merchant_invoice_path(@merchant1, @invoice1)
-       
+     
         expect(page).to have_content(@invoice1.id)
         expect(page).to have_content(@invoice1.status)
         expect(page).to have_content(@invoice1.created_at.strftime('%A, %B %d, %Y'))
@@ -46,13 +46,13 @@ RSpec.describe "Merchant Invoice Show" do
       it 'Displays item name, the quantity of the item ordered, price the item sold for, invoice item status, and i do not see any info related to items for other merchants' do 
        
         visit merchant_invoice_path(@merchant1, @invoice1)
-
+        save_and_open_page
         expect(page).to have_content(@item1.name)
         expect(page).to have_content(@item2.name)
-        expect(page).to have_content(@item2.unit_price)
-        expect(page).to have_content(@item1.unit_price)
-        expect(page).to have_content(@item1.quantity)
-        expect(page).to have_content(@item2.quantity)
+        expect(page).to have_content(@invoice_item1.unit_price)
+        expect(page).to have_content(@invoice_item2.unit_price)
+        expect(page).to have_content(@invoice_item1.quantity)
+        expect(page).to have_content(@invoice_item2.quantity)
         expect(page).to have_content(@item1.status)
         expect(page).to have_content(@item2.status)
         expect(page).to_not have_content(@item3.name)

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Merchant Invoice Show" do
     
     @invoice_item1 = InvoiceItem.create!(quantity: 1, unit_price: 5000, status: 0, item_id: @item1.id, invoice_id: @invoice1.id)
     @invoice_item2 =InvoiceItem.create!(quantity: 2, unit_price: 5000, status: 1, item_id: @item2.id, invoice_id: @invoice1.id)
-    @invoice_item3 = InvoiceItem.create!(quantity: 1, unit_price: 5000, status: 2, item_id: @item3.id, invoice_id: @invoice2.id)
+    @invoice_item3 = InvoiceItem.create!(quantity: 54, unit_price: 8000, status: 2, item_id: @item3.id, invoice_id: @invoice2.id)
 
   end
 
@@ -46,18 +46,18 @@ RSpec.describe "Merchant Invoice Show" do
       it 'Displays item name, the quantity of the item ordered, price the item sold for, invoice item status, and i do not see any info related to items for other merchants' do 
        
         visit merchant_invoice_path(@merchant1, @invoice1)
-        save_and_open_page
+        
         expect(page).to have_content(@item1.name)
         expect(page).to have_content(@item2.name)
         expect(page).to have_content(@invoice_item1.unit_price)
         expect(page).to have_content(@invoice_item2.unit_price)
         expect(page).to have_content(@invoice_item1.quantity)
         expect(page).to have_content(@invoice_item2.quantity)
-        expect(page).to have_content(@item1.status)
-        expect(page).to have_content(@item2.status)
+        expect(page).to have_content(@invoice_item1.status)
+        expect(page).to have_content(@invoice_item2.status)
         expect(page).to_not have_content(@item3.name)
-        expect(page).to_not have_content(@item3.unit_price)
-        expect(page).to_not have_content(@item3.quantity)
+        expect(page).to_not have_content(@invoice_item3.unit_price)
+        expect(page).to_not have_content(@invoice_item3.quantity)
 
       end
     end


### PR DESCRIPTION
Added enum status to invoice_items model 

Feat/Test for story 16

Displays information for Invoice items that belong to merchant invoice show page. 
Had to correct some of my test data that I had set up incorrectly. 

whenever I run bundle rspec I am getting a funny warning about bundler version 2.1.4 that is different then the lockfile which has 2.3.24

Is anyone else getting this? Or did someone do a bundle update? 