### PR TITLE
Ep/feat/merchant items enable disable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.9-x86_64-linux)
+      racc (~> 1.4)
     orderly (0.1.1)
       capybara (>= 1.1)
       rspec (>= 2.14)
@@ -219,6 +221,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,6 @@ GEM
       nokogiri (~> 1.8)
 
 PLATFORMS
-  ruby
   x86_64-darwin-21
 
 DEPENDENCIES

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,4 +5,24 @@ class ItemsController < ApplicationController
       @merchant.items 
     end
   end
+  
+  def show 
+
+    if params[:item_id]
+
+    @merchant = Merchant.find(params[:merchant_id])
+    end 
+
+
+  end
+  def update 
+    @merchant = Merchant.find(params[:merchant_id])
+    @item = Item.find(params[:id])
+    @item.update(status: params[:status])
+    @item.save 
+    redirect_to "/merchants/#{@merchant.id}/items"
+  
+
+  end
+
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,8 +1,10 @@
 <h1><center>Items for: <%=@merchant.name%></center></h1>
 
 <%@merchant.items.each do |item|%>
-  <p><%=item.name%>  <%=item.status%> 
-  <%=button_to "Enable", "/merchants/#{@merchant.id}/items/#{item.id}?status=Enabled", method: :patch %>
-  <%=button_to "Disable", "/merchants/#{@merchant.id}/items/#{item.id}?status=Disabled", method: :patch %>
-  </p>
+  <div id="merchant-item-<%=item.id%>">
+    <p><%=item.name%>  <%=item.status%> 
+    <%=button_to "Enable", "/merchants/#{@merchant.id}/items/#{item.id}?status=Enabled", method: :patch %>
+    <%=button_to "Disable", "/merchants/#{@merchant.id}/items/#{item.id}?status=Disabled", method: :patch %>
+    </p>
+  </div>  
 <%end %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,4 +1,5 @@
-<h2>Items for: <%=@merchant.name%></h2>
+<h1><center>Items for: <%=@merchant.name%></center></h1>
+
 <%@merchant.items.each do |item|%>
   <p><%=item.name%></p>
 <%end %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,5 +1,8 @@
 <h1><center>Items for: <%=@merchant.name%></center></h1>
 
 <%@merchant.items.each do |item|%>
-  <p><%=item.name%></p>
+  <p><%=item.name%>  <%=item.status%> 
+  <%=button_to "Enable", "/merchants/#{@merchant.id}/items/#{item.id}?status=Enabled", method: :patch %>
+  <%=button_to "Disable", "/merchants/#{@merchant.id}/items/#{item.id}?status=Disabled", method: :patch %>
+  </p>
 <%end %>

--- a/db/migrate/20221101191502_create_items.rb
+++ b/db/migrate/20221101191502_create_items.rb
@@ -4,6 +4,7 @@ class CreateItems < ActiveRecord::Migration[5.2]
       t.string :name
       t.string :description
       t.integer :unit_price
+      t.string :status 
       t.references :merchant, foreign_key: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2022_11_01_191651) do
     t.string "name"
     t.string "description"
     t.integer "unit_price"
+    t.string "status"
     t.bigint "merchant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -16,5 +16,18 @@ RSpec.describe 'merchant items index page' do
       expect(page).to have_content("Another")
       expect(page).to_not have_content("Other")
     end
+
+    it 'next to each item is a button to disable/ enable item which takes user back to items index with items status changed' do 
+      visit merchant_items_path(@klein_rempel)
+      expect(page).to_not have_content("Enabled")
+      click_button "Enable"
+      expect(page).to have_content("Enabled")
+      expect(page).to_not have_content("Disabled")
+      click_button "Disable"
+      expect(page).to have_content("Disabled")
+      expect(page).to_not have_content("Enabled")
+
+
+    end
   end
 end

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'merchant items index page' do
       @klein_rempel.items.create!(name: "Something", description: "A thing that is something", unit_price: 300)
       @klein_rempel.items.create!(name: "Another", description: "One more something", unit_price: 150)
       @whb.items.create!(name: "Other", description: "One more something", unit_price: 150)
-
+      @something = Item.first 
     end
     it 'i see a list of names of all my items but not those for other merchants' do 
       visit merchant_items_path(@klein_rempel)
@@ -19,15 +19,15 @@ RSpec.describe 'merchant items index page' do
 
     it 'next to each item is a button to disable/ enable item which takes user back to items index with items status changed' do 
       visit merchant_items_path(@klein_rempel)
-      expect(page).to_not have_content("Enabled")
-      click_button "Enable"
-      expect(page).to have_content("Enabled")
-      expect(page).to_not have_content("Disabled")
-      click_button "Disable"
-      expect(page).to have_content("Disabled")
-      expect(page).to_not have_content("Enabled")
-
-
+      within "#merchant-item-#{@something.id}" do 
+        expect(page).to_not have_content("Enabled")
+        click_button "Enable"
+        expect(page).to have_content("Enabled")
+        expect(page).to_not have_content("Disabled")
+        click_button "Disable"
+        expect(page).to have_content("Disabled")
+        expect(page).to_not have_content("Enabled")
+      end 
     end
   end
 end


### PR DESCRIPTION
Added Enable and Disable buttons to the merchants items index page. When a user clicks on the enable button it changes that merchant item's status to 'enabled'. When disable is clicked, the item's status changes to 'disabled'. The status can change between disabled and enabled when one of the buttons is clicked. Testing includes within block to test for specific buttons under a certain merchant item. 