### PR TITLE
Ep/feat/merchant items groupby status

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,7 +3,5 @@ class Item < ApplicationRecord
   has_many :invoices, through: :invoice_items
   belongs_to :merchant 
 
-  def group_by_enabled
-    items.select("name").where("status = 'Enabled'").pluck(:name)
-  end
+
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,4 +2,8 @@ class Item < ApplicationRecord
   has_many :invoice_items
   has_many :invoices, through: :invoice_items
   belongs_to :merchant 
+
+  def group_by_enabled
+    items.select("name").where("status = 'Enabled'").pluck(:name)
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -18,10 +18,10 @@ class Merchant < ApplicationRecord
   end
 
   def enabled_items
-    items.where("status = 'Enabled'")
+    items.where("status= ?", "Enabled")
   end
 
   def disabled_items
-    items.where("status = 'Disabled'")
+    items.where("status= ?", "Disabled")
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -12,4 +12,8 @@ class Merchant < ApplicationRecord
 
     Customer.select('customers.*, count(transactions.*) as num_transactions').joins(invoices: [:transactions, :items]).where("transactions.result = 0").where("items.merchant_id = ?", self.id).order('num_transactions desc').group(:id).limit(5)
   end
+
+  def group_by_enabled
+    items.select("name").where("status = 'Enabled'").pluck(:name)
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -13,7 +13,11 @@ class Merchant < ApplicationRecord
     Customer.select('customers.*, count(transactions.*) as num_transactions').joins(invoices: [:transactions, :items]).where("transactions.result = 0").where("items.merchant_id = ?", self.id).order('num_transactions desc').group(:id).limit(5)
   end
 
-  def group_by_enabled
+  def enabled_items
     items.select("name").where("status = 'Enabled'").pluck(:name)
+  end
+
+  def disabled_items
+    items.select("name").where("status = 'Disabled'").pluck(:name)
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -14,10 +14,10 @@ class Merchant < ApplicationRecord
   end
 
   def enabled_items
-    items.select("name").where("status = 'Enabled'").pluck(:name)
+    items.where("status = 'Enabled'")
   end
 
   def disabled_items
-    items.select("name").where("status = 'Disabled'").pluck(:name)
+    items.where("status = 'Disabled'")
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,16 +1,29 @@
 <h1><center>Items for: <%=@merchant.name%></center></h1>
-
-<%@merchant.items.each do |item|%>
-    <div id="item-disabled-<%=item.name%>">Enabled Items:
-    <%if item.status == "Enabled"%>
-      <%=item.name%>  <%=item.status%> 
-      <%=button_to "Disable", "/merchants/#{@merchant.id}/items/#{item.id}?status=Disabled", method: :patch %>
-    </div> 
-    <div id="item-enabled-<%=item.name%>">
-    <%elsif item.status == "Disabled"%>
-      <p>Disabled Items: <%=item.name%>  <%=item.status%> 
-      <%=button_to "Enable", "/merchants/#{@merchant.id}/items/#{item.id}?status=Enabled", method: :patch %>
+<div class="row">
+  <style>
+    .column {
+    float: left;
+    width: 50%;
+    }
+  </style>
+  <div class="column" id="enabled_items">
+    <h2>Enabled Items</h2>
+    <%@merchant.enabled_items.each do |item|%>
+      <section id="enabled-item-<%=item.name%>">
+        <%=item.name%>
+        <%=button_to "Disable", "/merchants/#{@merchant.id}/items/#{item.id}?status=Disabled", method: :patch %>
+      </section>
     <%end%>
-    
-  </div>  
-<%end %>
+  </div>
+  <div class="column", id="disabled_items">
+    <h2>Disabled Items</h2>
+    <%@merchant.disabled_items.each do |item|%>
+      <section id="disabled-item-<%=item.name%>">
+        <%=item.name%>
+        <%=button_to "Enable", "/merchants/#{@merchant.id}/items/#{item.id}?status=Enabled", method: :patch %>
+      </section>
+    <%end%>
+  </div>
+</div>
+
+

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -6,6 +6,7 @@
     width: 50%;
     }
   </style>
+
   <div class="column" id="enabled_items">
     <h2>Enabled Items</h2>
     <%@merchant.enabled_items.each do |item|%>
@@ -15,6 +16,7 @@
       </section>
     <%end%>
   </div>
+
   <div class="column", id="disabled_items">
     <h2>Disabled Items</h2>
     <%@merchant.disabled_items.each do |item|%>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,10 +1,16 @@
 <h1><center>Items for: <%=@merchant.name%></center></h1>
 
 <%@merchant.items.each do |item|%>
-  <div id="merchant-item-<%=item.id%>">
-    <p><%=item.name%>  <%=item.status%> 
-    <%=button_to "Enable", "/merchants/#{@merchant.id}/items/#{item.id}?status=Enabled", method: :patch %>
-    <%=button_to "Disable", "/merchants/#{@merchant.id}/items/#{item.id}?status=Disabled", method: :patch %>
-    </p>
+    <div id="item-disabled-<%=item.name%>">Enabled Items:
+    <%if item.status == "Enabled"%>
+      <%=item.name%>  <%=item.status%> 
+      <%=button_to "Disable", "/merchants/#{@merchant.id}/items/#{item.id}?status=Disabled", method: :patch %>
+    </div> 
+    <div id="item-enabled-<%=item.name%>">
+    <%elsif item.status == "Disabled"%>
+      <p>Disabled Items: <%=item.name%>  <%=item.status%> 
+      <%=button_to "Enable", "/merchants/#{@merchant.id}/items/#{item.id}?status=Enabled", method: :patch %>
+    <%end%>
+    
   </div>  
 <%end %>

--- a/db/migrate/20221103025651_add_default_status_to_item.rb
+++ b/db/migrate/20221103025651_add_default_status_to_item.rb
@@ -1,0 +1,5 @@
+class AddDefaultStatusToItem < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :items, :status, "Disabled"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_01_191651) do
+ActiveRecord::Schema.define(version: 2022_11_03_025651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 2022_11_01_191651) do
     t.string "name"
     t.string "description"
     t.integer "unit_price"
-    t.string "status"
+    t.string "status", default: "Disabled"
     t.bigint "merchant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe 'merchant items index page' do
       @something= @klein_rempel.items.create!(name: "Something", description: "A thing that is something", unit_price: 300, status: "Enabled")
       @another = @klein_rempel.items.create!(name: "Another", description: "One more something", unit_price: 150, status: "Enabled")
       @other = @whb.items.create!(name: "Other", description: "One more something", unit_price: 150)
+      @water= @klein_rempel.items.create!(name: "Water", description: "like the ocean", unit_price: 80, status: "Disabled")
+
     end
     it 'i see a list of names of all my items but not those for other merchants' do 
       visit merchant_items_path(@klein_rempel)
@@ -18,13 +20,12 @@ RSpec.describe 'merchant items index page' do
 
     it 'next to each item is a button to disable/ enable item which takes user back to items index with items status changed' do 
       visit merchant_items_path(@klein_rempel)
-      within "#item-enabled-#{@something.name}" do 
-        save_and_open_page
+      within "#enabled-item-#{@something.name}" do 
+        expect(page).to have_content("Something")
+        click_button "Disable"
+        expect(current_path).to eq(merchant_items_path(@klein_rempel))
+        # expect(page).to_not have_content("Something")
 
-        click_button "Enable"
-        expect(page).to have_content("Disabled")
-        expect(page).to_not have_content("Enabled")
-        save_and_open_page
       end 
 
       # expect(page).to_not have_content("Enabled")
@@ -35,6 +36,13 @@ RSpec.describe 'merchant items index page' do
 
     it 'Each item is split into two categories on the page, enabled items and disabled' do 
       visit merchant_items_path(@klein_rempel)
+      within('div#enabled_items') do 
+        expect(page).to have_content("Something")
+        within "#enabled-item-#{@something.name}" do 
+          click_button "Disable"
+        end 
+        expect(page).to_not have_content("Something")
+      end
     end
 
   

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'merchant items index page' do
       @another = @klein_rempel.items.create!(name: "Another", description: "One more something", unit_price: 150, status: "Enabled")
       @other = @whb.items.create!(name: "Other", description: "One more something", unit_price: 150)
       @water= @klein_rempel.items.create!(name: "Water", description: "like the ocean", unit_price: 80, status: "Disabled")
+      @ice= @klein_rempel.items.create!(name: "Ice", description: "water but better", unit_price: 80, status: "Disabled")
 
     end
     it 'i see a list of names of all my items but not those for other merchants' do 
@@ -24,28 +25,36 @@ RSpec.describe 'merchant items index page' do
         expect(page).to have_content("Something")
         click_button "Disable"
         expect(current_path).to eq(merchant_items_path(@klein_rempel))
-        # expect(page).to_not have_content("Something")
-
       end 
-
-      # expect(page).to_not have_content("Enabled")
-      # click_button "Enable"
-      # expect(page).to have_content("Enabled")
-      # expect(page).to_not have_content("Disabled")
     end
 
     it 'Each item is split into two categories on the page, enabled items and disabled' do 
       visit merchant_items_path(@klein_rempel)
       within('div#enabled_items') do 
         expect(page).to have_content("Something")
+        expect(page).to have_content("Another")
+        expect(page).to_not have_content("Ice")
+
         within "#enabled-item-#{@something.name}" do 
           click_button "Disable"
         end 
         expect(page).to_not have_content("Something")
+        expect(page).to have_content("Another")
+        expect(page).to_not have_content("Ice")
+
+      end
+
+      within('div#disabled_items') do 
+        expect(page).to have_content("Something")
+        expect(page).to have_content("Ice")
+
+        within "#disabled-item-#{@something.name}" do 
+          click_button "Enable"
+        end
+        expect(page).to_not have_content("Something")
+        expect(page).to have_content("Ice")
+
       end
     end
-
-  
-
   end
 end

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -5,10 +5,9 @@ RSpec.describe 'merchant items index page' do
     before :each do 
       @klein_rempel = Merchant.create!(name: "Klein, Rempel and Jones")
       @whb = Merchant.create!(name: "WHB")
-      @klein_rempel.items.create!(name: "Something", description: "A thing that is something", unit_price: 300)
-      @klein_rempel.items.create!(name: "Another", description: "One more something", unit_price: 150)
-      @whb.items.create!(name: "Other", description: "One more something", unit_price: 150)
-      @something = Item.first 
+      @something= @klein_rempel.items.create!(name: "Something", description: "A thing that is something", unit_price: 300, status: "Enabled")
+      @another = @klein_rempel.items.create!(name: "Another", description: "One more something", unit_price: 150, status: "Enabled")
+      @other = @whb.items.create!(name: "Other", description: "One more something", unit_price: 150)
     end
     it 'i see a list of names of all my items but not those for other merchants' do 
       visit merchant_items_path(@klein_rempel)
@@ -19,15 +18,26 @@ RSpec.describe 'merchant items index page' do
 
     it 'next to each item is a button to disable/ enable item which takes user back to items index with items status changed' do 
       visit merchant_items_path(@klein_rempel)
-      within "#merchant-item-#{@something.id}" do 
-        expect(page).to_not have_content("Enabled")
+      within "#item-enabled-#{@something.name}" do 
+        save_and_open_page
+
         click_button "Enable"
-        expect(page).to have_content("Enabled")
-        expect(page).to_not have_content("Disabled")
-        click_button "Disable"
         expect(page).to have_content("Disabled")
         expect(page).to_not have_content("Enabled")
+        save_and_open_page
       end 
+
+      # expect(page).to_not have_content("Enabled")
+      # click_button "Enable"
+      # expect(page).to have_content("Enabled")
+      # expect(page).to_not have_content("Disabled")
     end
+
+    it 'Each item is split into two categories on the page, enabled items and disabled' do 
+      visit merchant_items_path(@klein_rempel)
+    end
+
+  
+
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -7,20 +7,6 @@ RSpec.describe Item do
     it { should belong_to :merchant }
   end
 
-  describe '#group_by_status' do 
-    before :each do 
-      @klein_rempel = Merchant.create!(name: "Klein, Rempel and Jones")
-      @whb = Merchant.create!(name: "WHB")
-      @something= @klein_rempel.items.create!(name: "Something", description: "A thing that is something", unit_price: 300, status: "Enabled")
-      @another = @klein_rempel.items.create!(name: "Another", description: "One more something", unit_price: 150, status: "Enabled")
-      @other = @whb.items.create!(name: "Other", description: "One more something", unit_price: 150)
-    end
 
-    it 'can be grouped by status enabled or disabled' do 
-      require 'pry'; binding.pry
-      expect(Item.group_by_enabled).to eq([@something, @another])
-      expect(Item.group_by_enabled).to_not eq([@other])
-    end
-  end
 
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -6,4 +6,21 @@ RSpec.describe Item do
     it { should have_many(:invoices).through(:invoice_items) }
     it { should belong_to :merchant }
   end
+
+  describe '#group_by_status' do 
+    before :each do 
+      @klein_rempel = Merchant.create!(name: "Klein, Rempel and Jones")
+      @whb = Merchant.create!(name: "WHB")
+      @something= @klein_rempel.items.create!(name: "Something", description: "A thing that is something", unit_price: 300, status: "Enabled")
+      @another = @klein_rempel.items.create!(name: "Another", description: "One more something", unit_price: 150, status: "Enabled")
+      @other = @whb.items.create!(name: "Other", description: "One more something", unit_price: 150)
+    end
+
+    it 'can be grouped by status enabled or disabled' do 
+      require 'pry'; binding.pry
+      expect(Item.group_by_enabled).to eq([@something, @another])
+      expect(Item.group_by_enabled).to_not eq([@other])
+    end
+  end
+
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -88,18 +88,26 @@ RSpec.describe Merchant do
     expect(@merchant1.top_five_customers).to eq([@customer1, @customer2, @customer3, @customer4, @customer5])
   end
 
-  describe '#group_by_status' do 
+  describe 'grouping by status' do 
     before :each do 
       @klein_rempel = Merchant.create!(name: "Klein, Rempel and Jones")
       @whb = Merchant.create!(name: "WHB")
       @something= @klein_rempel.items.create!(name: "Something", description: "A thing that is something", unit_price: 300, status: "Enabled")
       @another = @klein_rempel.items.create!(name: "Another", description: "One more something", unit_price: 150, status: "Enabled")
+      @water= @klein_rempel.items.create!(name: "Water", description: "like the ocean", unit_price: 80, status: "Disabled")
       @other = @whb.items.create!(name: "Other", description: "One more something", unit_price: 150)
     end
 
-    it 'can be grouped by status enabled or disabled' do 
-      expect(@klein_rempel.group_by_enabled).to eq([@something.name, @another.name])
-      expect(@klein_rempel.group_by_enabled).to_not eq([@other.name])
+    it 'returns a list of merchant items that are enabled' do 
+      expect(@klein_rempel.enabled_items).to eq([@something.name, @another.name])
+      expect(@klein_rempel.enabled_items).to_not eq([@other.name])
     end
+
+    it 'returns a list of merchant items that are disabled' do 
+      expect(@klein_rempel.disabled_items).to eq([@water.name])
+      expect(@klein_rempel.disabled_items).to_not eq([@another.name, @something.name])
+
+    end
+
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -87,4 +87,19 @@ RSpec.describe Merchant do
 
     expect(@merchant1.top_five_customers).to eq([@customer1, @customer2, @customer3, @customer4, @customer5])
   end
+
+  describe '#group_by_status' do 
+    before :each do 
+      @klein_rempel = Merchant.create!(name: "Klein, Rempel and Jones")
+      @whb = Merchant.create!(name: "WHB")
+      @something= @klein_rempel.items.create!(name: "Something", description: "A thing that is something", unit_price: 300, status: "Enabled")
+      @another = @klein_rempel.items.create!(name: "Another", description: "One more something", unit_price: 150, status: "Enabled")
+      @other = @whb.items.create!(name: "Other", description: "One more something", unit_price: 150)
+    end
+
+    it 'can be grouped by status enabled or disabled' do 
+      expect(@klein_rempel.group_by_enabled).to eq([@something.name, @another.name])
+      expect(@klein_rempel.group_by_enabled).to_not eq([@other.name])
+    end
+  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -99,13 +99,13 @@ RSpec.describe Merchant do
     end
 
     it 'returns a list of merchant items that are enabled' do 
-      expect(@klein_rempel.enabled_items).to eq([@something.name, @another.name])
-      expect(@klein_rempel.enabled_items).to_not eq([@other.name])
+      expect(@klein_rempel.enabled_items).to eq([@something, @another])
+      expect(@klein_rempel.enabled_items).to_not eq([@other])
     end
 
     it 'returns a list of merchant items that are disabled' do 
-      expect(@klein_rempel.disabled_items).to eq([@water.name])
-      expect(@klein_rempel.disabled_items).to_not eq([@another.name, @something.name])
+      expect(@klein_rempel.disabled_items).to eq([@water])
+      expect(@klein_rempel.disabled_items).to_not eq([@another, @something])
 
     end
 


### PR DESCRIPTION
Created two methods in the merchant model to group merchant items into an enabled status category and a disabled status category. Used these methods to separate out the list of items and their enable/disable buttons on the merchant items index page. Added within blocks to testing to ensure we are testing the correct spot on the page. 