### PR TITLE
Ep/feat/admin invoice show

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,13 +19,17 @@ class ItemsController < ApplicationController
 
   def update 
     @merchant = Merchant.find(params[:merchant_id]) 
-    @item = Item.find(params[:id])
-    @item.update!(item_params)
-    #@item.update(status: params[:status])
-    #@item.save 
-    flash.notice = "The Information Has Successfully Updated"
-    # redirect_to "/merchants/#{@merchant.id}/items"
-    redirect_to "/merchants/#{@item.merchant.id}/items/#{@item.id}"
+    if params[:status]
+      @item = Item.find(params[:id])
+      @item.update(status: params[:status])
+      @item.save 
+      redirect_to "/merchants/#{@merchant.id}/items"
+    else 
+      @item = Item.find(params[:id])
+      @item.update!(item_params)
+      flash.notice = "The Information Has Successfully Updated"
+      redirect_to "/merchants/#{@item.merchant.id}/items/#{@item.id}"
+    end
   end
 
   def new 

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper' 
+
+RSpec.describe 'Admin Invoice Show Page' do 
+  before :each do 
+    @merchant1 = Merchant.create!(name: "Kevin's Illegal goods")
+    @merchant2 = Merchant.create!(name: "Denver PC parts")
+
+    @customer1 = Customer.create!(first_name: "Sean", last_name: "Culliton")
+    @customer2 = Customer.create!(first_name: "Sergio", last_name: "Azcona")
+    @customer3 = Customer.create!(first_name: "Emily", last_name: "Port")
+
+    @item1 = @merchant1.items.create!(name: "Funny Brick of Powder", description: "White Powder with Gasoline Smell", unit_price: 5000)
+    @item2 = @merchant1.items.create!(name: "T-Rex", description: "Skull of a Dinosaur", unit_price: 100000)
+    @item3 = @merchant2.items.create!(name: "UFO Board", description: "Out of this world MotherBoard", unit_price: 400)
+
+    @invoice1 = Invoice.create!(status: 1, customer_id: @customer2.id, created_at: "2022-11-01 11:00:00 UTC")
+    @invoice2 = Invoice.create!(status: 1, customer_id: @customer1.id, created_at: "2022-11-01 11:00:00 UTC")
+    @invoice3 = Invoice.create!(status: 1, customer_id: @customer3.id, created_at: "2022-11-01 11:00:00 UTC")
+    
+    @invoice_item1 = InvoiceItem.create!(quantity: 1, unit_price: 5000, status: 0, item_id: @item1.id, invoice_id: @invoice1.id)
+    @invoice_item2 =InvoiceItem.create!(quantity: 2, unit_price: 5000, status: 1, item_id: @item2.id, invoice_id: @invoice1.id)
+    @invoice_item3 = InvoiceItem.create!(quantity: 54, unit_price: 8000, status: 2, item_id: @item3.id, invoice_id: @invoice2.id)
+
+  end
+
+  describe 'as an admin when i visit admin invoice show page' do 
+    it 'i see invoice id, status, crated at date, and customer first and last name' do 
+      
+    end
+  end
+end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -1,28 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin Merchant show page' do 
-  before (:each) do 
-      @klein_rempel = Merchant.create!(name: "Klein, Rempel and Jones", status: "Disabled")
-      @whb = Merchant.create!(name: "WHB", status: "Enabled")
-      @lisa_frank = Merchant.create!(name: 'Lisa Frank Knockoffs', status: 'Enabled')
-      @burger = Merchant.create!(name: 'Burger King', status: 'Disabled')
+  before :each do 
+    @klein_rempel = Merchant.create!(name: "Klein, Rempel and Jones", status: "Disabled")
+    @whb = Merchant.create!(name: "WHB", status: "Enabled")
+    @lisa_frank = Merchant.create!(name: 'Lisa Frank Knockoffs', status: 'Enabled')
+    @burger = Merchant.create!(name: 'Burger King', status: 'Disabled')
+  
+  end 
 
-      
-    end 
+  it 'As an admin, when I click on the name of a merchant from the admin merchant index page' do
+    visit admin_merchants_path
+    expect(page).to have_link("#{@burger.name}")
+    click_link("#{@burger.name}")
+    expect(current_path).to eq(admin_merchant_path(@burger))
+  end 
+  
+  it " After clicking on merchant from index page, I am taken to the merchant admin show page, and I see the name of that merchant" do 
+    visit admin_merchant_path(@burger.id)
+    expect(page).to have_content(@burger.name)
+    expect(page).to have_content(@burger.status)
+  end
 
-    it 'As an admin, when I click on the name of a merchant from the admin merchant index page' do
-      visit admin_merchants_path
-
-      expect(page).to have_link("#{@burger.name}")
-      click_link("#{@burger.name}")
-      expect(current_path).to eq(admin_merchant_path(@burger))
-    end 
-    
-    it " After clicking on merchant from index page, I am taken to the merchant admin show page, and I see the name of that merchant" do 
-      visit admin_merchant_path(@burger.id)
-
-      expect(page).to have_content(@burger.name)
-      expect(page).to have_content(@burger.status)
-    end
+  
+   
 end 
 

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Merchant Invoice Show" do
       it 'when I click the update item status button I am taken back to merchant invoice show page
           and status has been updated' do 
         visit merchant_invoice_path(@merchant1, @invoice1)
-        within "#invoice_item-#{@invoice1.id}" do
+        within "#invoice_item-#{@invoice_item1.id}" do
         first(:radio_button, 'status').click 
           expect(page).to have_button("Update Item Status")
           click_button('Update Item Status')


### PR DESCRIPTION
Added if params[:status] to update method in items controller because we needed two redirect paths depending on what the params inputted was. The params[:status] goes to the updating disabled/enabled status and directing back to items index page and then else goes to when a user updates/ edits a merchant's item's attributes on merchant item show page. I also updated one failing test in the merchant invoices show spec file because the expected path in the test was entered incorrectly (typo). Now all tests pass.  Coverage is at 99.89% so we should go back and check simplecov report to see what methods we aren't testing. 